### PR TITLE
feat: audit suggestions

### DIFF
--- a/src/Delegation.sol
+++ b/src/Delegation.sol
@@ -12,7 +12,6 @@ import {
     ENTRY_POINT_V8
 } from "./types/Constants.sol";
 import {EIP712} from "solady/utils/EIP712.sol";
-import {ECDSA} from "solady/utils/ECDSA.sol";
 
 contract Delegation is IERC7821, IERC1271, IERC4337, EIP712 {
     error UnsupportedExecutionMode();
@@ -48,7 +47,42 @@ contract Delegation is IERC7821, IERC1271, IERC4337, EIP712 {
         _;
     }
 
+    modifier onlyEntryPoint() {
+        if (msg.sender != entryPoint()) {
+            revert InvalidCaller();
+        }
+        _;
+    }
+
+    fallback() external payable {}
+
     receive() external payable {}
+
+    function onERC721Received(address, address, uint256, bytes calldata)
+        external
+        pure
+        returns (bytes4)
+    {
+        return this.onERC721Received.selector;
+    }
+
+    function onERC1155Received(address, address, uint256, uint256, bytes calldata)
+        external
+        pure
+        returns (bytes4)
+    {
+        return this.onERC1155Received.selector;
+    }
+
+    function onERC1155BatchReceived(
+        address,
+        address,
+        uint256[] calldata,
+        uint256[] calldata,
+        bytes calldata
+    ) external pure returns (bytes4) {
+        return this.onERC1155BatchReceived.selector;
+    }
 
     function execute(bytes32 mode, bytes calldata executionData) external payable {
         _execute(mode, executionData, false);
@@ -68,24 +102,34 @@ contract Delegation is IERC7821, IERC1271, IERC4337, EIP712 {
         return true;
     }
 
+    // https://eips.ethereum.org/EIPS/eip-1271
     function isValidSignature(bytes32 digest, bytes calldata signature)
         external
         view
         returns (bytes4)
     {
-        // https://eips.ethereum.org/EIPS/eip-1271
         return _verifySignature(digest, signature) ? bytes4(0x1626ba7e) : bytes4(0xffffffff);
     }
 
-    function validateUserOp(PackedUserOperation calldata userOp, bytes32 userOpHash, uint256)
-        external
-        view
-        returns (uint256)
-    {
-        // https://eips.ethereum.org/EIPS/eip-4337
+    function validateUserOp(
+        PackedUserOperation calldata userOp,
+        bytes32 userOpHash,
+        uint256 missingAccountFunds
+    ) external onlyEntryPoint returns (uint256) {
+        if (missingAccountFunds != 0) {
+            (bool success,) = payable(msg.sender).call{value: missingAccountFunds}("");
+            (success);
+        }
+
         return _verifySignature(userOpHash, userOp.signature) ? 0 : 1;
     }
 
+    function entryPoint() public pure returns (address) {
+        // https://github.com/eth-infinitism/account-abstraction/releases/tag/v0.8.0
+        return ENTRY_POINT_V8;
+    }
+
+    // https://eips.ethereum.org/EIPS/eip-4337
     function getNonce(uint192 key) external view returns (uint256) {
         Storage storage s = _getStorage();
         return _encodeNonce(key, s.nonceSequenceNumber[key]);
@@ -125,12 +169,12 @@ contract Delegation is IERC7821, IERC1271, IERC4337, EIP712 {
             // address(this)`.
             // If `msg.sender` is an authorized entry point, then `execute` MAY accept calls from
             // the entry point.
-            if (msg.sender != address(this) && msg.sender != ENTRY_POINT_V8 && !allowUnauthorized) {
+            if (msg.sender != address(this) && msg.sender != entryPoint() && !allowUnauthorized) {
                 revert Unauthorized();
             }
 
             _executeCalls(calls);
-        } else {
+        } else if (modeSelector == EXEC_MODE_OP_DATA) {
             bytes calldata opData = _decodeOpData(executionData);
             bytes calldata signature = _decodeSignature(opData);
 
@@ -144,13 +188,17 @@ contract Delegation is IERC7821, IERC1271, IERC4337, EIP712 {
             }
 
             _executeCalls(calls);
+        } else {
+            revert UnsupportedExecutionMode();
         }
     }
 
     function _executeCalls(Call[] calldata calls) internal {
         for (uint256 i = 0; i < calls.length; i++) {
-            (bool success, bytes memory data) =
-                calls[i].to.call{value: calls[i].value}(calls[i].data);
+            Call calldata call = calls[i];
+            address to = call.to == address(0) ? address(this) : call.to;
+
+            (bool success, bytes memory data) = to.call{value: call.value}(call.data);
 
             if (!success) {
                 assembly {
@@ -205,12 +253,35 @@ contract Delegation is IERC7821, IERC1271, IERC4337, EIP712 {
         }
     }
 
+    function _decodeSignatureComponents(bytes calldata signature)
+        internal
+        pure
+        returns (bytes32 r, bytes32 s, uint8 v)
+    {
+        assembly {
+            r := calldataload(signature.offset)
+            s := calldataload(add(signature.offset, 0x20))
+            v := byte(0, calldataload(add(signature.offset, 0x40)))
+        }
+    }
+
     function _verifySignature(bytes32 digest, bytes calldata signature)
         internal
         view
         returns (bool)
     {
-        return ECDSA.recoverCalldata(digest, signature) == address(this);
+        if (signature.length != 65) {
+            return false;
+        }
+
+        (bytes32 r, bytes32 s, uint8 v) = _decodeSignatureComponents(signature);
+
+        // https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/cryptography/ECDSA.sol#L134-L145
+        if (uint256(s) > 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0) {
+            return false;
+        }
+
+        return ecrecover(digest, v, r, s) == address(this);
     }
 
     function _computeDigest(bytes32 mode, Call[] calldata calls, uint256 nonce)

--- a/src/Delegation.sol
+++ b/src/Delegation.sol
@@ -18,6 +18,7 @@ contract Delegation is IERC7821, IERC1271, IERC4337, EIP712 {
     error InvalidCaller();
     error InvalidSignatureLength();
     error InvalidSignatureS();
+    error InvalidSignature();
     error Unauthorized();
     error InvalidNonce();
     error ExcessiveInvalidation();
@@ -282,12 +283,13 @@ contract Delegation is IERC7821, IERC1271, IERC4337, EIP712 {
             revert InvalidSignatureS();
         }
 
-        // The reference implementation also checks the recovered address against the zero address
-        // indicating that the address cannot be recovered or not enough gas was provided. The code
-        // below performs this check implicitly and avoids making this additional check to reduce
-        // gas overhead. The difference is that it doesn't distinguish between the signer being the
-        // zero address and the signer being someone other than the owner (both are invalid)
-        return ecrecover(digest, v, r, s) == address(this);
+        address signer = ecrecover(digest, v, r, s);
+
+        if (signer == address(0)) {
+            revert InvalidSignature();
+        }
+
+        return signer == address(this);
     }
 
     function _computeDigest(bytes32 mode, Call[] calldata calls, uint256 nonce)


### PR DESCRIPTION
Implements suggestions from the [audit](https://notes.watchpug.com/p/196ae7f8c17wBxG-) and follow up [audit](https://notes.watchpug.com/p/19714e0c787giBnI).

Notably this does not address the following:

### [`WP-L7`](https://notes.watchpug.com/p/196ae7f8c17wBxG-#n_2)
We support two modes from [`EIP-7821`](https://eips.ethereum.org/EIPS/eip-7821) namely `single batch` and `single batch with optional data` but not `batch of batches`. For `single batch` mode which doesn't support optional data we authorize based on the caller (since there is no additional data to authenticate the user). For `single batch with optional data` we assume optional data is present since this is the only way we can authenticate the user (e.g., via an ECDSA signature). If no optional data is present, the caller should instead just use `single batch` (not `single batch with optional data`). We don't want to support the case where mode is `single batch with optional data` but no optional data is specified since there is no way to authenticate the user.

### [`WP-I8`](https://notes.watchpug.com/p/196ae7f8c17wBxG-#n_7)
Since we use our own [`ERC-7201`](https://eips.ethereum.org/EIPS/eip-7201) storage namespace, we avoid collisions with our storage. As long as our storage layout remains the same between versions we plan to keep the same storage namespace to reuse the existing storage (e.g., nonces). If, however, we need to change the storage layout we plan to introduce a new version number to our namespace to avoid storage collisions with the previous version (e.g., `erc7201:gelato.delegation.storage.v0.0.1`). The domain separator version will also be changed alongside this to prevent replay attacks. For now it is also preferred if we can avoid having an initialization function unless required.

As mentioned according to [`EIP-7702`](https://github.com/ethereum/EIPs/blob/015f08bba346696a02379f1dec40cd38db38b2c9/EIPS/eip-7702.md?plain=1#L537-L553):

> Changing an account's delegation is a security-critical operation that should
> not be done lightly, especially if the newly delegated code is not purposely
> designed and tested as an upgrade to the old one.
> 
> In particular, in order to ensure a safe migration of an account from one
> delegate contract to another, it's important for these contracts to use storage
> in a way that avoids accidental collisions among them. For example, using
> [ERC-7201](https://eips.ethereum.org/EIPS/eip-7201) a contract may root its storage layout at a slot
> dependent on a unique identifier. To simplify this, smart contract languages may
> provide a way of re-rooting the entire storage layout of existing contract
> source code.
> 
> If all contracts previously delegated to by the account used the approach
> described above, a migration should not cause any issues. However, if there is
> any doubt, it is recommended to first clear all account storage, an operation
> that is not natively offered by the protocol but that a special-purpose delegate
> contract can be designed to implement.

According to the above, a special-purpose delegate contract is required to clear storage since this is not natively offered by the protocol. This delegate would have to explicitly clear the storage at our unique storage namespace in order to reset the nonce and allow signature replay attacks. A contract that illegitimately clears storage in our namespace would be considered malicious and could directly steal funds from the user anyway if delegated to without the extra steps of clearing nonce storage and replaying signatures.

### [`WP-I10`](https://notes.watchpug.com/p/196ae7f8c17wBxG-#n_14)
This will be implemented in a follow up PR/commit.