### PR TITLE
feat: add `getBalanceAfterExecute` to simulation

### DIFF
--- a/src/Delegation.sol
+++ b/src/Delegation.sol
@@ -193,7 +193,9 @@ contract Delegation is IERC7821, IERC1271, IERC4337, EIP712 {
         _getStorage().nonceSequenceNumber[key] = targetSeq;
     }
 
-    function _execute(bytes32 mode, bytes calldata executionData, bool mockSignature) internal {
+    function _execute(bytes32 mode, bytes calldata executionData, bool allowUnauthorized)
+        internal
+    {
         (bytes1 callType, bytes1 execType, bytes4 modeSelector,) = _decodeExecutionMode(mode);
 
         if (callType != CALL_TYPE_BATCH || execType != EXEC_TYPE_DEFAULT) {
@@ -208,7 +210,7 @@ contract Delegation is IERC7821, IERC1271, IERC4337, EIP712 {
             // address(this)`.
             // If `msg.sender` is an authorized entry point, then `execute` MAY accept calls from
             // the entry point.
-            if (msg.sender != address(this) && msg.sender != entryPoint()) {
+            if (msg.sender != address(this) && msg.sender != entryPoint() && !allowUnauthorized) {
                 revert Unauthorized();
             }
 
@@ -229,7 +231,7 @@ contract Delegation is IERC7821, IERC1271, IERC4337, EIP712 {
             // If `signature` length is 65, treat it as secp256k1 signature.
             // Otherwise, invoke the specified validator module.
             if (signature.length == 65) {
-                if (!_verifySignature(digest, signature) && !mockSignature) {
+                if (!_verifySignature(digest, signature) && !allowUnauthorized) {
                     revert Unauthorized();
                 }
 
@@ -242,7 +244,8 @@ contract Delegation is IERC7821, IERC1271, IERC4337, EIP712 {
                 }
 
                 if (
-                    !validator.validate(calls, msg.sender, digest, innerSignature) && !mockSignature
+                    !validator.validate(calls, msg.sender, digest, innerSignature)
+                        && !allowUnauthorized
                 ) {
                     revert Unauthorized();
                 }

--- a/src/Simulation.sol
+++ b/src/Simulation.sol
@@ -2,15 +2,25 @@
 pragma solidity ^0.8.29;
 
 import {Delegation} from "./Delegation.sol";
+import {NATIVE_TOKEN} from "./types/Constants.sol";
+import {IERC20} from "./interfaces/IERC20.sol";
 
 contract Simulation is Delegation {
-    function simulateExecute(bytes32 mode, bytes calldata executionData)
+    function simulateExecute(bytes32 mode, bytes calldata executionData) external payable {
+        _execute(mode, executionData, true);
+    }
+
+    function getBalanceAfterExecute(bytes32 mode, bytes calldata executionData, address token)
         external
         payable
         returns (uint256)
     {
-        uint256 gas = gasleft();
         _execute(mode, executionData, true);
-        return gas - gasleft();
+
+        if (token == NATIVE_TOKEN) {
+            return address(this).balance;
+        }
+
+        return IERC20(token).balanceOf(address(this));
     }
 }

--- a/src/interfaces/IERC20.sol
+++ b/src/interfaces/IERC20.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.29;
+
+// https://eips.ethereum.org/EIPS/eip-20
+interface IERC20 {
+    function balanceOf(address owner) external view returns (uint256 balance);
+}

--- a/src/types/Constants.sol
+++ b/src/types/Constants.sol
@@ -10,3 +10,5 @@ bytes4 constant EXEC_MODE_OP_DATA = 0x78210001;
 
 // https://eips.ethereum.org/EIPS/eip-4337
 address constant ENTRY_POINT_V8 = 0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108;
+
+address constant NATIVE_TOKEN = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;


### PR DESCRIPTION
Required by `relay-api-gateway` [#324](https://github.com/gelatodigital/relay-api-gateway/pull/323).